### PR TITLE
Fix some LGTM alerts

### DIFF
--- a/.github/workflows/ci-unittests.yml
+++ b/.github/workflows/ci-unittests.yml
@@ -62,8 +62,6 @@ jobs:
           then
             pip install -r "$REQ_FILE"
           fi
-      - name: DEBUG what package is being imported?
-        run: python -c "import smqtk_dataprovider; print(smqtk_dataprovider)"
       - name: Run Unittests
         run: pytest --cov=smqtk_dataprovider --cov-config=.pytest.coveragerc
 

--- a/docs/release_notes/pending_release.rst
+++ b/docs/release_notes/pending_release.rst
@@ -11,3 +11,9 @@ Updates / New Features
 
 Fixes
 -----
+
+CI
+
+* Remove a debug command in a GitHub CI workflow job.
+
+* Fix some LGTM warnings.

--- a/smqtk_dataprovider/impls/data_element/file.py
+++ b/smqtk_dataprovider/impls/data_element/file.py
@@ -11,7 +11,7 @@ from smqtk_dataprovider.utils.file import safe_file_write
 STR_NONE_TYPES = (str, type(None))
 
 
-class DataFileElement (DataElement):
+class DataFileElement (DataElement):  # lgtm [py/missing-equals]
     """
     File-based data element
     """

--- a/smqtk_dataprovider/impls/data_element/girder.py
+++ b/smqtk_dataprovider/impls/data_element/girder.py
@@ -15,7 +15,7 @@ except ImportError:
 LOG = logging.getLogger(__name__)
 
 
-class GirderDataElement (DataElement):
+class GirderDataElement (DataElement):  # lgtm [py/missing-equals]
     """
     Element whose data is stored via a Girder backend.  Accesses via Girder
     REST API given user credentials.

--- a/smqtk_dataprovider/impls/data_element/hbase.py
+++ b/smqtk_dataprovider/impls/data_element/hbase.py
@@ -12,7 +12,7 @@ except ImportError:
     tika_detector = None
 
 
-class HBaseDataElement(DataElement):
+class HBaseDataElement(DataElement):  # lgtm [py/missing-equals]
     """
     Wrapper for binary data contained on an HBase server somewhere. Uses Tika
     content type detection to determine content type of served data.

--- a/smqtk_dataprovider/impls/data_element/hbase.py
+++ b/smqtk_dataprovider/impls/data_element/hbase.py
@@ -6,11 +6,9 @@ from smqtk_dataprovider.exceptions import ReadOnlyError
 # attempt to import required modules
 try:
     import happybase  # type: ignore
-    import tika  # type: ignore
-    from tika import detector as tika_detector
+    from tika import detector as tika_detector  # type: ignore
 except ImportError:
     happybase = None
-    tika = None
     tika_detector = None
 
 

--- a/smqtk_dataprovider/impls/data_element/memory.py
+++ b/smqtk_dataprovider/impls/data_element/memory.py
@@ -11,7 +11,7 @@ BYTES_CONFIG_ENCODING = 'latin-1'
 T = TypeVar("T", bound="DataMemoryElement")
 
 
-class DataMemoryElement (DataElement):
+class DataMemoryElement (DataElement):  # lgtm [py/missing-equals]
     """
     In-memory representation of data stored in a byte list
     """

--- a/smqtk_dataprovider/impls/data_element/url.py
+++ b/smqtk_dataprovider/impls/data_element/url.py
@@ -11,7 +11,7 @@ from smqtk_dataprovider.exceptions import InvalidUriError, ReadOnlyError
 MIMETYPES = mimetypes.MimeTypes()
 
 
-class DataUrlElement (DataElement):
+class DataUrlElement (DataElement):  # lgtm [py/missing-equals]
     """
     Representation of data loadable via a web URL address.
     """


### PR DESCRIPTION
There were some warnings that classes did not implement equality operator extensions for subclass added attributes. In those cases those attributes were not the important piece of information that equality should operate over for those types: they only serve the purpose for accessing the data over which is primarily served (bytes) whose value would dictate equality. NOTE: this LGTM issue does not go away until its merged into master (says their own docs).

There was also an unneeded import, so that was removed.

Sneaking in here a removal of a "debug" line in the github actions CI workflow that wasn't removed before.